### PR TITLE
Add serialVersionUID to all serializable objects

### DIFF
--- a/src/tuataraTMSim/machine/Alphabet.java
+++ b/src/tuataraTMSim/machine/Alphabet.java
@@ -35,6 +35,11 @@ import tuataraTMSim.machine.TM.TM_Machine; // !!!
 public class Alphabet implements Serializable, Cloneable
 {
     /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new instance of Alphabet. Default is binary alphabet.
      */
     public Alphabet()

--- a/src/tuataraTMSim/machine/CA_Tape.java
+++ b/src/tuataraTMSim/machine/CA_Tape.java
@@ -37,6 +37,11 @@ import tuataraTMSim.MainWindow;
 public class CA_Tape extends Tape implements Serializable 
 {   
     /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new instance of CA_Tape.
      */
     public CA_Tape()

--- a/src/tuataraTMSim/machine/DFSA/DFSA_Action.java
+++ b/src/tuataraTMSim/machine/DFSA/DFSA_Action.java
@@ -36,6 +36,11 @@ import tuataraTMSim.machine.*;
 public class DFSA_Action extends PreAction
 {
     /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
+    /**
      * Creates an instance of DFSA_Action.
      * @param match The character this action matches.
      */

--- a/src/tuataraTMSim/machine/DFSA/DFSA_Machine.java
+++ b/src/tuataraTMSim/machine/DFSA/DFSA_Machine.java
@@ -50,6 +50,11 @@ import tuataraTMSim.NamingScheme;
 public class DFSA_Machine extends Machine<DFSA_Action, DFSA_Transition, DFSA_State, DFSA_Simulator>
 {
     /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new instance of DFSA_Machine.
      * @param states The set of states.
      * @param transitions The set of transitions.

--- a/src/tuataraTMSim/machine/DFSA/DFSA_State.java
+++ b/src/tuataraTMSim/machine/DFSA/DFSA_State.java
@@ -37,6 +37,11 @@ import tuataraTMSim.machine.*;
 public class DFSA_State extends State<DFSA_Action, DFSA_Transition, DFSA_Machine, DFSA_Simulator>
 {
     /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new instance of DFSA_State, with a specified location.
      * @param label The label for the state.
      * @param startState Whether or not this state is the start state.

--- a/src/tuataraTMSim/machine/DFSA/DFSA_Transition.java
+++ b/src/tuataraTMSim/machine/DFSA/DFSA_Transition.java
@@ -38,6 +38,11 @@ import tuataraTMSim.Spline;
 public class DFSA_Transition extends Transition<DFSA_Action, DFSA_State, DFSA_Machine, DFSA_Simulator>
 {
     /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
+    /**
      * Creates a new instance of DFSA_Transition.
      */
     public DFSA_Transition()

--- a/src/tuataraTMSim/machine/Machine.java
+++ b/src/tuataraTMSim/machine/Machine.java
@@ -46,6 +46,11 @@ public abstract class Machine<
     SIMULATOR extends Simulator<PREACTION, TRANSITION, STATE, ?>> implements Serializable
 {
     /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
+    /**
      * Does not match anything; instead, this is used to indicate that an action has not yet been
      * assigned a value.
      */

--- a/src/tuataraTMSim/machine/PreAction.java
+++ b/src/tuataraTMSim/machine/PreAction.java
@@ -36,6 +36,11 @@ import tuataraTMSim.exceptions.TapeBoundsException;
 public abstract class PreAction implements Serializable
 {
     /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
+    /**
      * Creates an instance of PreAction.
      * @param dir The direction the read/write head should move.
      * @param input The value for which if read from the tape, the action will occur.

--- a/src/tuataraTMSim/machine/State.java
+++ b/src/tuataraTMSim/machine/State.java
@@ -40,6 +40,11 @@ public abstract class State<
     SIMULATOR extends Simulator<PREACTION, TRANSITION, ?, MACHINE>> implements Serializable
 {
     /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
+    /**
      * Width of the graphical representation of the state, in pixels.
      */
     public static final int STATE_RENDERING_WIDTH = 30;

--- a/src/tuataraTMSim/machine/TM/TM_Action.java
+++ b/src/tuataraTMSim/machine/TM/TM_Action.java
@@ -40,8 +40,13 @@ import tuataraTMSim.machine.*;
  * writing to the tape.
  * @author Jimmy
  */
-public class TM_Action extends PreAction implements Serializable
+public class TM_Action extends PreAction
 {
+    /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
     /**
      * Character representing a left-shift to the read/write head of the tape.
      */

--- a/src/tuataraTMSim/machine/TM/TM_Machine.java
+++ b/src/tuataraTMSim/machine/TM/TM_Machine.java
@@ -52,8 +52,12 @@ import tuataraTMSim.TMGraphicsPanel;
  * @author Jimmy
  */
 public class TM_Machine extends Machine<TM_Action, TM_Transition, TM_State, TM_Simulator>
-    implements Serializable
 {
+    /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
     /**
      * Matches symbols which do not have a transition. Multiple OTHERWISE transitions are not permitted.
      */

--- a/src/tuataraTMSim/machine/TM/TM_State.java
+++ b/src/tuataraTMSim/machine/TM/TM_State.java
@@ -38,8 +38,12 @@ import tuataraTMSim.machine.*;
  * @author Jimmy
  */
 public class TM_State extends State<TM_Action, TM_Transition, TM_Machine, TM_Simulator>
-    implements Serializable
 {
+    /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
     /**
      * Width of the graphical representation of the state, in pixels.
      */

--- a/src/tuataraTMSim/machine/TM/TM_Transition.java
+++ b/src/tuataraTMSim/machine/TM/TM_Transition.java
@@ -38,8 +38,12 @@ import tuataraTMSim.Spline;
  * @author Jimmy
  */
 public class TM_Transition extends Transition<TM_Action, TM_State, TM_Machine, TM_Simulator> 
-    implements Serializable
 {
+    /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
     /**
      * Creates a new instance of TM_Transition.
      */

--- a/src/tuataraTMSim/machine/Tape.java
+++ b/src/tuataraTMSim/machine/Tape.java
@@ -35,6 +35,11 @@ import tuataraTMSim.MainWindow;
 public abstract class Tape implements Serializable
 {
     /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
+    /**
      * The character used to represent a blank symbol, which fill the tape.
      */
     public static final char BLANK_SYMBOL = '_';

--- a/src/tuataraTMSim/machine/Transition.java
+++ b/src/tuataraTMSim/machine/Transition.java
@@ -41,6 +41,11 @@ public abstract class Transition<
     SIMULATOR extends Simulator<PREACTION, ?, STATE, MACHINE>> implements Serializable
 {
     /**
+     * Serialization version.
+     */
+    public static final long serialVersionUID = 1L;
+
+    /**
      * Number of pixels for arrowheads on transitions.
      */
     public static final double ARROWHEAD_LENGTH = 6;


### PR DESCRIPTION
Fix #40 

All machine related classes now define a serialVersionUID. This should be incremented whenever a breaking change is made to the type.