### PR TITLE
Prevent toolbar from being drawn over, fix minimum size for window

### DIFF
--- a/src/tuataraTMSim/MainWindow.java
+++ b/src/tuataraTMSim/MainWindow.java
@@ -359,7 +359,7 @@ public class MainWindow extends JFrame
     private void initComponents()
     {
         // Set up the main window
-        setSize(new Dimension(640, 480));
+        setMinimumSize(new Dimension(640, 480));
         setTitle("Tuatara Turing Machine Simulator");
         setIconImage(Global.loadIcon("tuatara.gif").getImage());
 

--- a/src/tuataraTMSim/ToolBarPanel.java
+++ b/src/tuataraTMSim/ToolBarPanel.java
@@ -139,6 +139,16 @@ class ToolBarPanel extends JPanel
     }
 
     /**
+     * Get the minimum size for this component.
+     * @return The minimum size for this component.
+     */
+    public Dimension getMinimumSize()
+    {
+        // NOTE: By returning preferred size, we can prevent the toolbar from being drawn over
+        return getPreferredSize();
+    }
+
+    /**
      * The owning component.
      */
     private Component m_parent;


### PR DESCRIPTION
Before, when the toolbar was forced to use two rows [or more], the JSplitPane housing the console and desktop pane would be rendered slightly on top of the toolbar. This pull fixes this issue by assigning the toolbar a minimum size.