### PR TITLE
Rename accepting -> final for consistency

### DIFF
--- a/src/tuataraTMSim/GUI_Mode.java
+++ b/src/tuataraTMSim/GUI_Mode.java
@@ -56,9 +56,9 @@ public enum GUI_Mode
     CHOOSESTART,
 
     /**
-     * Choose the accepting state of the machine.
+     * Choose the final state of the machine.
      */
-    CHOOSEACCEPTING,
+    CHOOSEFINAL,
 
     /**
      * Choose the currently executing state of the machine.

--- a/src/tuataraTMSim/MachineGraphicsPanel.java
+++ b/src/tuataraTMSim/MachineGraphicsPanel.java
@@ -114,7 +114,7 @@ public abstract class MachineGraphicsPanel<
         m_contextMenu.add(m_addStateAction);
         m_contextMenu.add(m_renameStateAction);
         m_contextMenu.add(m_toggleStartAction);
-        m_contextMenu.add(m_toggleAcceptingAction);
+        m_contextMenu.add(m_toggleFinalAction);
         m_contextMenu.add(m_deleteStateAction);
         m_contextMenu.addSeparator();
         m_contextMenu.add(m_resetLabelsAction);
@@ -474,8 +474,8 @@ public abstract class MachineGraphicsPanel<
                         handleChooseStartClick(e);
                         break;
 
-                    case CHOOSEACCEPTING:
-                        handleChooseAcceptingClick(e);
+                    case CHOOSEFINAL:
+                        handleChooseFinalClick(e);
                         break;
 
                     case SELECTION:
@@ -1321,16 +1321,16 @@ public abstract class MachineGraphicsPanel<
     }
 
     /**
-     * Handle when a mouse click occurs while in select accepting state mode. If the mouse click
-     * occurs over a state, the accepting state of the machine is changed.
+     * Handle when a mouse click occurs while in select final state mode. If the mouse click
+     * occurs over a state, the final state of the machine is changed.
      * @param e The generating event.
      */
-    protected void handleChooseAcceptingClick(MouseEvent e)
+    protected void handleChooseFinalClick(MouseEvent e)
     {
         STATE stateClickedOn = m_sim.getMachine().getStateClickedOn(e.getX(), e.getY());
         if (stateClickedOn != null)
         {
-            doCommand(new ToggleAcceptingStateCommand(this, stateClickedOn));
+            doCommand(new ToggleFinalStateCommand(this, stateClickedOn));
         }
     }
 
@@ -1750,14 +1750,14 @@ public abstract class MachineGraphicsPanel<
         };
 
     /**
-     * Action which toggles whether or not the selected state is accepting.
+     * Action which toggles whether or not the selected state is final.
      */
-    protected Action m_toggleAcceptingAction = 
-        new TriggerAction("Toggle Accepting", TRIGGER_STATE)
+    protected Action m_toggleFinalAction = 
+        new TriggerAction("Toggle Final", TRIGGER_STATE)
         {
             public void actionPerformed(ActionEvent e)
             {
-                doCommand(new ToggleAcceptingStateCommand(MachineGraphicsPanel.this, m_contextState));
+                doCommand(new ToggleFinalStateCommand(MachineGraphicsPanel.this, m_contextState));
             }
         };
 

--- a/src/tuataraTMSim/MainWindow.java
+++ b/src/tuataraTMSim/MainWindow.java
@@ -523,10 +523,10 @@ public class MainWindow extends JFrame
         modeMenu.add(m_chooseStartMenuItem);
         modeMenuItems.add(m_chooseStartMenuItem);
         
-        JRadioButtonMenuItem m_chooseAcceptingMenuItem = new JRadioButtonMenuItem(m_chooseAcceptingAction);
-        m_chooseAcceptingAction.setMenuItem(m_chooseAcceptingMenuItem);
-        modeMenu.add(m_chooseAcceptingMenuItem);
-        modeMenuItems.add(m_chooseAcceptingMenuItem);
+        JRadioButtonMenuItem m_chooseFinalMenuItem = new JRadioButtonMenuItem(m_chooseFinalAction);
+        m_chooseFinalAction.setMenuItem(m_chooseFinalMenuItem);
+        modeMenu.add(m_chooseFinalMenuItem);
+        modeMenuItems.add(m_chooseFinalMenuItem);
         
         JRadioButtonMenuItem m_chooseCurrentStateMenuItem = new JRadioButtonMenuItem(m_chooseCurrentStateAction);
         m_chooseCurrentStateAction.setMenuItem(m_chooseCurrentStateMenuItem);
@@ -717,8 +717,8 @@ public class MainWindow extends JFrame
         GUIModeButton startStatesToolBarButton = new GUIModeButton(m_chooseStartAction, GUI_Mode.CHOOSESTART);
         m_toolbarButtons.add(startStatesToolBarButton);
         
-        GUIModeButton acceptingStatesToolBarButton = new GUIModeButton(m_chooseAcceptingAction, GUI_Mode.CHOOSEACCEPTING);
-        m_toolbarButtons.add(acceptingStatesToolBarButton);
+        GUIModeButton finalStatesToolBarButton = new GUIModeButton(m_chooseFinalAction, GUI_Mode.CHOOSEFINAL);
+        m_toolbarButtons.add(finalStatesToolBarButton);
         
         GUIModeButton chooseCurrentStateToolBarButton = new GUIModeButton(m_chooseCurrentStateAction, GUI_Mode.CHOOSECURRENTSTATE);
         m_toolbarButtons.add(chooseCurrentStateToolBarButton);
@@ -773,7 +773,7 @@ public class MainWindow extends JFrame
         returner[1].add(selectionToolBarButton);
         returner[1].add(eraserToolBarButton);
         returner[1].add(startStatesToolBarButton);
-        returner[1].add(acceptingStatesToolBarButton);
+        returner[1].add(finalStatesToolBarButton);
         returner[1].add(chooseCurrentStateToolBarButton);
         
         returner[2] = new JToolBar("Machine");
@@ -1043,7 +1043,7 @@ public class MainWindow extends JFrame
             m_eraserAction.setEnabled(isEnabled);
             m_selectionAction.setEnabled(isEnabled);
             m_chooseStartAction.setEnabled(isEnabled);
-            m_chooseAcceptingAction.setEnabled(isEnabled);
+            m_chooseFinalAction.setEnabled(isEnabled);
             m_chooseCurrentStateAction.setEnabled(isEnabled);
             
             m_slowExecuteSpeedAction.setEnabled(isEnabled);
@@ -1076,7 +1076,7 @@ public class MainWindow extends JFrame
         m_eraserAction.setEnabled(isEnabled);
         m_selectionAction.setEnabled(isEnabled);
         m_chooseStartAction.setEnabled(isEnabled);
-        m_chooseAcceptingAction.setEnabled(isEnabled);
+        m_chooseFinalAction.setEnabled(isEnabled);
         m_chooseCurrentStateAction.setEnabled(isEnabled);
         
         m_newTuringMachineAction.setEnabled(isEnabled);
@@ -2213,10 +2213,10 @@ public class MainWindow extends JFrame
             Global.loadIcon("startState.png"), KeyStroke.getKeyStroke(KeyEvent.VK_F6,0));
 
     /**
-     * Action associated with CHOOSEACCEPTING.
+     * Action associated with CHOOSEFINAL.
      */
-    public final GUI_ModeSelectionAction m_chooseAcceptingAction = 
-        new GUI_ModeSelectionAction("Choose Accepting State", GUI_Mode.CHOOSEACCEPTING,
+    public final GUI_ModeSelectionAction m_chooseFinalAction = 
+        new GUI_ModeSelectionAction("Choose Final State", GUI_Mode.CHOOSEFINAL,
             Global.loadIcon("finalState.png"), KeyStroke.getKeyStroke(KeyEvent.VK_F7,0));
 
     /**

--- a/src/tuataraTMSim/commands/ToggleFinalStateCommand.java
+++ b/src/tuataraTMSim/commands/ToggleFinalStateCommand.java
@@ -29,23 +29,23 @@ import tuataraTMSim.MachineGraphicsPanel;
 import tuataraTMSim.machine.State;
 
 /**
- * A command which deals with changing the accepting state of a machine.
+ * A command which deals with changing the final state of a machine.
  */
-public class ToggleAcceptingStateCommand implements TMCommand
+public class ToggleFinalStateCommand implements TMCommand
 {
     /**
-     * Creates a new instance of ToggleAcceptingCommand.
+     * Creates a new instance of ToggleFinalCommand.
      * @param panel The current graphics panel.
      * @param state The state to toggle.
      */
-    public ToggleAcceptingStateCommand(MachineGraphicsPanel panel, State state)
+    public ToggleFinalStateCommand(MachineGraphicsPanel panel, State state)
     {
         m_panel = panel;
         m_state = state;
     }
     
     /**
-     * Toggle whether or not the supplied state is accepting.
+     * Toggle whether or not the supplied state is final.
      */
     public void doCommand()
     {
@@ -53,7 +53,7 @@ public class ToggleAcceptingStateCommand implements TMCommand
     }
     
     /**
-     * Toggle whether or not the supplied state is accepting.
+     * Toggle whether or not the supplied state is final.
      */
     public void undoCommand()
     {
@@ -66,7 +66,7 @@ public class ToggleAcceptingStateCommand implements TMCommand
      */
     public String getName()
     {
-        return "Toggle Accepting State";
+        return "Toggle Final State";
     }
     
     /**

--- a/src/tuataraTMSim/commands/ToggleStartStateCommand.java
+++ b/src/tuataraTMSim/commands/ToggleStartStateCommand.java
@@ -45,7 +45,7 @@ public class ToggleStartStateCommand implements TMCommand
     }
     
     /**
-     * Toggle whether or not the supplied state is accepting.
+     * Toggle whether or not the supplied state is a start state.
      */
     public void doCommand()
     {
@@ -53,7 +53,7 @@ public class ToggleStartStateCommand implements TMCommand
     }
     
     /**
-     * Toggle whether or not the supplied state is accepting.
+     * Toggle whether or not the supplied state is a start state.
      */
     public void undoCommand()
     {

--- a/src/tuataraTMSim/help/keyShortcuts.html
+++ b/src/tuataraTMSim/help/keyShortcuts.html
@@ -108,7 +108,7 @@ This is a comprehensive list of the keyboard shortcuts in Tuatara Turing Machine
 </tr>
 
 <tr>
-<td> <img src="../images/finalState.png"> Choose Accepting State </td>
+<td> <img src="../images/finalState.png"> Choose Final State </td>
 <td> F7 </td> 
 </tr>
 

--- a/src/tuataraTMSim/help/menuReference.html
+++ b/src/tuataraTMSim/help/menuReference.html
@@ -148,14 +148,14 @@ The purpose of each menu item is stated briefly here for reference purposes.
 <td> <img src="../images/startState.png"> </td>
 <td> <b> Choose Start State </b> </td>
 <td> - </td>
-<td> Select the user interface mode to choose a start state (initial state). </td>
+<td> Select the user interface mode to choose a start state. </td>
 </tr>
 
 <tr>
 <td> <img src="../images/finalState.png"> </td>
-<td> <b> Choose Accepting State </b> </td>
+<td> <b> Choose Final State </b> </td>
 <td> - </td>
-<td> Select the user interface mode to choose an accepting state (final state). </td>
+<td> Select the user interface mode to choose a final state. </td>
 </tr>
 
 <tr>

--- a/src/tuataraTMSim/machine/DFSA/DFSA_Action.java
+++ b/src/tuataraTMSim/machine/DFSA/DFSA_Action.java
@@ -31,7 +31,7 @@ import tuataraTMSim.exceptions.ComputationFailedException;
 import tuataraTMSim.machine.*;
 
 /**
- * An action for a state transition of a DFSA, which consists only of accepting a character.
+ * An action for a state transition of a DFSA, which consists only of final a character.
  */
 public class DFSA_Action extends PreAction
 {

--- a/src/tuataraTMSim/machine/DFSA/DFSA_Machine.java
+++ b/src/tuataraTMSim/machine/DFSA/DFSA_Machine.java
@@ -44,7 +44,7 @@ import tuataraTMSim.machine.*;
  * - X is a finite alphabet, consisting of input characters
  * - d is a total function, with QxX mapping to Q
  * - q0 is the unique start state
- * - F is a subset of Q, denoting the accepting states
+ * - F is a subset of Q, denoting the final states
  */
 public class DFSA_Machine extends Machine<DFSA_Action, DFSA_Transition, DFSA_State, DFSA_Simulator>
 {

--- a/src/tuataraTMSim/machine/DFSA/DFSA_Simulator.java
+++ b/src/tuataraTMSim/machine/DFSA/DFSA_Simulator.java
@@ -84,12 +84,12 @@ public class DFSA_Simulator extends Simulator<DFSA_Action, DFSA_Transition, DFSA
     } 
     
     /**
-     * Determine if the machine is in an accepting state.
-     * @return true if the machine is in an accepting state, false otherwise.
+     * Determine if the machine is in a final state.
+     * @return true if the machine is in a final state, false otherwise.
      */
     public boolean isAccepted()
     {
-        // Accepted input means no more input, and last state is accepting
+        // Accepted input means no more input, and last state is final
         return isHalted() && m_state != null && m_state.isFinalState();
     }
  

--- a/src/tuataraTMSim/machine/Simulator.java
+++ b/src/tuataraTMSim/machine/Simulator.java
@@ -138,8 +138,8 @@ public abstract class Simulator<
     public abstract boolean isHalted();
     
     /**
-     * Determine if the machine is in an accepting state.
-     * @return true if the machine is in an accepting state, false otherwise.
+     * Determine if the machine is in a final state.
+     * @return true if the machine is in a final state, false otherwise.
      */
     public abstract boolean isAccepted();
  

--- a/src/tuataraTMSim/machine/State.java
+++ b/src/tuataraTMSim/machine/State.java
@@ -91,7 +91,7 @@ public abstract class State<
     }
 
     /**
-     * Change whether this state is an accepting state or not.
+     * Change whether this state is a final state or not.
      * @param value true if this state should be the final state, false otherwise.
      */
     public void setFinalState(boolean value)

--- a/src/tuataraTMSim/machine/TM/TM_Machine.java
+++ b/src/tuataraTMSim/machine/TM/TM_Machine.java
@@ -210,19 +210,19 @@ public class TM_Machine extends Machine<TM_Action, TM_Transition, TM_State, TM_S
         {
             throw new ComputationFailedException(
                     "The machine halted, but the r/w head was not parked, " +
-                    "and the last state was not an accepting state");
+                    "and the last state was not a final state");
         }
         // Halted
         else if (!tape.isParked())
         {
             throw new ComputationFailedException(
-                    "The machine halted in an accepting state, but the r/w head was not parked");
+                    "The machine halted in a final state, but the r/w head was not parked");
         }
         // Halted
         else
         {
             throw new ComputationFailedException(
-                    "The machine halted with the r/w head parked, but was not in an accepting state");
+                    "The machine halted with the r/w head parked, but was not in a final state");
         }      
     }
 

--- a/src/tuataraTMSim/machine/TM/TM_Simulator.java
+++ b/src/tuataraTMSim/machine/TM/TM_Simulator.java
@@ -89,8 +89,8 @@ public class TM_Simulator extends Simulator<TM_Action, TM_Transition, TM_State, 
     }
 
     /** 
-     * Determine if the machine is in an accepting state.
-     * @return true if the machine is in an accepting state, false otherwise.
+     * Determine if the machine is in a final state.
+     * @return true if the machine is in a final state, false otherwise.
      */
     public boolean isHalted()
     {
@@ -98,9 +98,9 @@ public class TM_Simulator extends Simulator<TM_Action, TM_Transition, TM_State, 
     }
 
     /**
-     * Determine if the machine is in an accepting state, and the read/write head of the tape is in
+     * Determine if the machine is in a final state, and the read/write head of the tape is in
      * the first cell of the tape.
-     * @return true if the machine is in an accepting state, with the read/write head parked, false
+     * @return true if the machine is in a final state, with the read/write head parked, false
      *         otherwise.
      */
     public boolean isAccepted()


### PR DESCRIPTION
Reason: Project was split between using `accepting` and `final` for describing final states