### PR TITLE
Change how timer tasks are scheduled to mitigate lurches in simulation

### DIFF
--- a/src/tuataraTMSim/ExecutionTimerTask.java
+++ b/src/tuataraTMSim/ExecutionTimerTask.java
@@ -52,6 +52,11 @@ public class ExecutionTimerTask extends TimerTask
      */
     public void run()
     {
+        // TODO: Since sim.step() has the potential to block [by prompting the user for a choice],
+        //       we may end up with the simulation 'skipping' a state; this is because the timer
+        //       queues the next run of the task while this is blocking, and immediately run after
+        //       the prompt is finished.
+
         MainWindow inst = MainWindow.getInstance();
 
         try

--- a/src/tuataraTMSim/MainWindow.java
+++ b/src/tuataraTMSim/MainWindow.java
@@ -52,12 +52,7 @@ public class MainWindow extends JFrame
      * The layer used for internal frames containing machines.
      */
     protected static final int MACHINE_WINDOW_LAYER = 50;
-   
-    /**
-     * Internal timer.
-     */
-    protected final java.util.Timer m_timer = new java.util.Timer(true);
-    
+       
     /**
      * String for execution halting.
      */
@@ -1781,6 +1776,11 @@ public class MainWindow extends JFrame
     private final JFileChooser m_fcTape = new JFileChooser();
 
     /**
+     * Internal timer for repeatedly calling m_timerTask.
+     */
+    protected final java.util.Timer m_timer = new java.util.Timer(true);
+
+    /**
      * Timer task used for stepping through a machine on a delay.
      */
     private ExecutionTimerTask m_timerTask;
@@ -2334,7 +2334,7 @@ public class MainWindow extends JFrame
                     }
                     setEditingEnabled(false);
                     m_timerTask = new ExecutionTimerTask(panel, m_tapeDisp);
-                    m_timer.scheduleAtFixedRate(m_timerTask, 0, m_executionDelayTime);
+                    m_timer.schedule(m_timerTask, 0, m_executionDelayTime);
                 }
             }
         };


### PR DESCRIPTION
This is NOT a perfect fix; if the user takes too long in the prompt, the next step will seemingly be skipped visually; while the simulation still occurs, this is because the timer queues based off of task start times, not stop times.