### PR TITLE
Fix small issue where endPartial is called after a logPartial

### DIFF
--- a/src/tuataraTMSim/MainWindow.java
+++ b/src/tuataraTMSim/MainWindow.java
@@ -2293,11 +2293,11 @@ public class MainWindow extends JFrame
                     if (sim.isHalted())
                     {
                         m_console.logPartial(gfxPanel, sim.getConfiguration());
+                        m_console.endPartial();
                     }
                     else
                     {
                         m_console.logPartial(gfxPanel, "%s %c ", sim.getConfiguration(), Global.CONFIG_TEE);
-                        m_console.endPartial();
                     }
                 }
                 // Machine halted as expected


### PR DESCRIPTION
Causes configuration sequences to be printed on seperate lines rather than on the same line