### PR TITLE
Fix typo in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ are needed:
 To compile, clone the repo and run `make`:
 
 ```
-git clone https://github.com/mitchgrout/TuatararaTuringMachine.git
+git clone https://github.com/mitchgrout/TuataraTuringMachine.git
 cd TuataraTuringMachine
 make
 ```


### PR DESCRIPTION
"TuatararaTuringMachine" is not the name of the project to be cloned, updated to match project name.